### PR TITLE
A few changes for anonymous user login and multiline return status from FTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ func main() {
     var err error
     var ftp *goftp.FTP
 
-    // to enable debug messages, call: goftp.ConnectDbg("ftp.server.com:21")
+    // For debug messages: goftp.ConnectDbg("ftp.server.com:21")
     if ftp, err = goftp.Connect("ftp.server.com:21"); err != nil {
         panic(err)
     }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ func main() {
     var err error
     var ftp *goftp.FTP
 
-    if ftp, err = goftp.Connect("ftp.server.com:21", true); err != nil {
+	// to enable debug messages, call: goftp.ConnectDbg("ftp.server.com:21")
+    if ftp, err = goftp.Connect("ftp.server.com:21"); err != nil {
         panic(err)
     }
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ func main() {
     var err error
     var ftp *goftp.FTP
 
-	// to enable debug messages, call: goftp.ConnectDbg("ftp.server.com:21")
+    // to enable debug messages, call: goftp.ConnectDbg("ftp.server.com:21")
     if ftp, err = goftp.Connect("ftp.server.com:21"); err != nil {
         panic(err)
     }

--- a/ftp.go
+++ b/ftp.go
@@ -388,10 +388,11 @@ func (ftp *FTP) List(path string) (files []string, err error) {
 		return
 	}
 
-	// _, err = ftp.writer.WriteString(fmt.Sprintf("LIST %s\r\n", path))
-	// check for features LIST / MLSD
+	// check if MLSD works
 	if err = ftp.send("MLSD %s", path); err != nil {
-		return
+		if err = ftp.send("LIST %s", path); err != nil {
+			return
+		}
 	}
 
 	var pconn net.Conn
@@ -440,7 +441,13 @@ func (ftp *FTP) List(path string) (files []string, err error) {
 // login to the server
 func (ftp *FTP) Login(username string, password string) (err error) {
 	if _, err = ftp.cmd("331", "USER %s", username); err != nil {
-		return
+		if strings.HasPrefix(err.Error(), "230") {
+			// Ok, probably anonymous server
+			// but login was fine, so return no error
+			err = nil
+		} else {
+			return
+		}
 	}
 
 	if _, err = ftp.cmd("230", "PASS %s", password); err != nil {
@@ -451,7 +458,7 @@ func (ftp *FTP) Login(username string, password string) (err error) {
 }
 
 // connect to server
-func Connect(addr string) (*FTP, error) {
+func Connect(addr string, debugp bool) (*FTP, error) {
 	var err error
 	var conn net.Conn
 
@@ -466,7 +473,7 @@ func Connect(addr string) (*FTP, error) {
 
 	line, err = reader.ReadString('\n')
 
-	var debug bool = true
+	var debug bool = debugp
 
 	if debug {
 		log.Print(line)

--- a/ftp.go
+++ b/ftp.go
@@ -474,8 +474,8 @@ func (ftp *FTP) Login(username string, password string) (err error) {
 	return
 }
 
-// connect to server
-func Connect(addr string, debugp bool) (*FTP, error) {
+// connect to server, debug is OFF
+func Connect(addr string) (*FTP, error) {
 	var err error
 	var conn net.Conn
 
@@ -496,5 +496,28 @@ func Connect(addr string, debugp bool) (*FTP, error) {
 		log.Print(line)
 	}
 
-	return &FTP{conn: conn, addr: addr, reader: reader, writer: writer, debug: debug}, nil
+	return &FTP{conn: conn, addr: addr, reader: reader, writer: writer, debug: false}, nil
+}
+
+// connect to server, debug is ON
+func ConnectDbg(addr string) (*FTP, error) {
+	var err error
+	var conn net.Conn
+
+	if conn, err = net.Dial("tcp", addr); err != nil {
+		return nil, err
+	}
+
+	writer := bufio.NewWriter(conn)
+	reader := bufio.NewReader(conn)
+
+	var line string
+
+	line, err = reader.ReadString('\n')
+
+	if debug {
+		log.Print(line)
+	}
+
+	return &FTP{conn: conn, addr: addr, reader: reader, writer: writer, debug: true}, nil
 }

--- a/ftp.go
+++ b/ftp.go
@@ -495,15 +495,7 @@ func Connect(addr string) (*FTP, error) {
 	writer := bufio.NewWriter(conn)
 	reader := bufio.NewReader(conn)
 
-	var line string
-
-	line, err = reader.ReadString('\n')
-
-	var debug bool = debugp
-
-	if debug {
-		log.Print(line)
-	}
+	reader.ReadString('\n')
 
 	return &FTP{conn: conn, addr: addr, reader: reader, writer: writer, debug: false}, nil
 }
@@ -524,9 +516,7 @@ func ConnectDbg(addr string) (*FTP, error) {
 
 	line, err = reader.ReadString('\n')
 
-	if debug {
-		log.Print(line)
-	}
+	log.Print(line)
 
 	return &FTP{conn: conn, addr: addr, reader: reader, writer: writer, debug: true}, nil
 }

--- a/ftp.go
+++ b/ftp.go
@@ -215,7 +215,7 @@ func (ftp *FTP) receiveLine() (string, error) {
 	line, err := ftp.reader.ReadString('\n')
 
 	if ftp.debug {
-		fmt.Printf("< %s\n", line)
+		log.Printf("< %s", line)
 	}
 
 	return line, err

--- a/ftp.go
+++ b/ftp.go
@@ -211,11 +211,28 @@ func (ftp *FTP) Type(t string) error {
 	return err
 }
 
-func (ftp *FTP) receive() (string, error) {
+func (ftp *FTP) receiveLine() (string, error) {
 	line, err := ftp.reader.ReadString('\n')
 
 	if ftp.debug {
-		log.Printf("< %s", line)
+		fmt.Printf("< %s\n", line)
+	}
+
+	return line, err
+}
+
+func (ftp *FTP) receive() (string, error) {
+	line, err := ftp.receiveLine()
+
+	if err != nil {
+		return line, err
+	}
+
+	if line[3] == '-' {
+		nextLine := ""
+		// This is a continuation of output line
+		nextLine, err = ftp.receive()
+		line = line + nextLine
 	}
 
 	return line, err


### PR DESCRIPTION
I made a few changes while I was trying to create a small program using goftp library that would connect to an ftp server like ftp.gnu.org. The changes are:

1. Provision for anonymous logins where the username is enough to login successfully (i.e. anonymous user for ftp.gnu.org). In such cases sending the user name would return status 230 and there is no need to send password.

2. Added an extra parameter to Connect to set debug status.

3. Multi-line receive. If the FTP server returns multi-line status code, then currently the receive command will read only the first line and all subsequent command will produce return the rest of lines from the first command instead of the proper response. So changed the implementation to something similar to Ruby's Net::FTP class. Please refer here: http://rxr.whitequark.org/mri/source/lib/net/ftp.rb

4. Send LIST if MLSD fails. In some cases (old FTP servers) MLSD might fail as unknown command, while LIST will work. So updated code to send LIST when MLSD fails with error.

Please review the changes. Since I am a starting Go developer (and Git user) I would be happy to know your feedback on these. Thanks.
