### PR TITLE
Fix 'List' bug - list response receive 2 answers without sending

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -377,7 +377,6 @@ func (ftp *FTP) Pasv() (port int, err error) {
 	if line, err = ftp.cmd("227", "PASV"); err != nil {
 		return
 	}
-
 	re, err := regexp.Compile(`\((.*)\)`)
 
 	res := re.FindAllStringSubmatch(line, -1)
@@ -544,7 +543,7 @@ func (ftp *FTP) Retr(path string, retrFn RetrFunc) (s string, err error) {
 	defer pconn.Close()
 
 	var line string
-	if line, err = ftp.receive(); err != nil {
+	if line, err = ftp.receiveNoDiscard(); err != nil {
 		return
 	}
 
@@ -556,6 +555,8 @@ func (ftp *FTP) Retr(path string, retrFn RetrFunc) (s string, err error) {
 	if err = retrFn(pconn); err != nil {
 		return
 	}
+
+	pconn.Close()
 
 	if line, err = ftp.receive(); err != nil {
 		return
@@ -620,7 +621,6 @@ func (ftp *FTP) List(path string) (files []string, err error) {
 
 	for {
 		line, err = reader.ReadString('\n')
-
 		if err == io.EOF {
 			break
 		} else if err != nil {
@@ -629,6 +629,8 @@ func (ftp *FTP) List(path string) (files []string, err error) {
 
 		files = append(files, string(line))
 	}
+	// Must close for vsftp tlsed conenction otherwise does not receive connection
+	pconn.Close()
 
 	if line, err = ftp.receive(); err != nil {
 		return

--- a/ftp.go
+++ b/ftp.go
@@ -12,6 +12,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 )
 
 // RePwdPath is the default expression for matching files in the current working directory
@@ -36,10 +37,10 @@ func (ftp *FTP) Close() {
 }
 
 type (
-	// WalkFunc is called on each path in a Walk. Errors are filtered through WalkFunc
+// WalkFunc is called on each path in a Walk. Errors are filtered through WalkFunc
 	WalkFunc func(path string, info os.FileMode, err error) error
 
-	// RetrFunc is passed to Retr and is the handler for the stream received for a given path
+// RetrFunc is passed to Retr and is the handler for the stream received for a given path
 	RetrFunc func(r io.Reader) error
 )
 
@@ -266,13 +267,13 @@ func (ftp *FTP) Type(t TypeCode) error {
 type TypeCode string
 
 const (
-	// TypeASCII for ASCII
+// TypeASCII for ASCII
 	TypeASCII = "A"
-	// TypeEBCDIC for EBCDIC
+// TypeEBCDIC for EBCDIC
 	TypeEBCDIC = "E"
-	// TypeImage for an Image
+// TypeImage for an Image
 	TypeImage = "I"
-	// TypeLocal for local byte size
+// TypeLocal for local byte size
 	TypeLocal = "L"
 )
 
@@ -372,21 +373,43 @@ func (ftp *FTP) send(command string, arguments ...interface{}) error {
 }
 
 // Pasv enables passive data connection and returns port number
+
 func (ftp *FTP) Pasv() (port int, err error) {
-	var line string
-	if line, err = ftp.cmd("227", "PASV"); err != nil {
+	doneChan := make(chan int, 1)
+	go func() {
+		defer func() {
+			doneChan <- 1
+		}()
+		var line string
+		if line, err = ftp.cmd("227", "PASV"); err != nil {
+			return
+		}
+		re := regexp.MustCompile(`\((.*)\)`)
+		res := re.FindAllStringSubmatch(line, -1)
+		if len(res) == 0 || len(res[0]) < 2 {
+			err = errors.New("PasvBadAnswer")
+			return
+		}
+		s := strings.Split(res[0][1], ",")
+		if len(s) < 2 {
+			err = errors.New("PasvBadAnswer")
+			return
+		}
+		l1, _ := strconv.Atoi(s[len(s)-2])
+		l2, _ := strconv.Atoi(s[len(s)-1])
+
+		port = l1<<8 + l2
+
 		return
+	}()
+
+	select {
+	case _ = <-doneChan:
+
+	case <-time.After(time.Second * 10):
+		err = errors.New("PasvTimeout")
+		ftp.Close()
 	}
-	re, err := regexp.Compile(`\((.*)\)`)
-
-	res := re.FindAllStringSubmatch(line, -1)
-
-	s := strings.Split(res[0][1], ",")
-
-	l1, _ := strconv.Atoi(s[len(s)-2])
-	l2, _ := strconv.Atoi(s[len(s)-1])
-
-	port = l1<<8 + l2
 
 	return
 }
@@ -496,8 +519,8 @@ func (ftp *FTP) Stat(path string) ([]string, error) {
 		return nil, err
 	}
 	if !strings.HasPrefix(stat, StatusFileStatus) &&
-		!strings.HasPrefix(stat, StatusDirectoryStatus) &&
-		!strings.HasPrefix(stat, StatusSystemStatus) {
+	!strings.HasPrefix(stat, StatusDirectoryStatus) &&
+	!strings.HasPrefix(stat, StatusSystemStatus) {
 		return nil, errors.New(stat)
 	}
 	if strings.HasPrefix(stat, StatusSystemStatus) {
@@ -749,3 +772,4 @@ func (ftp *FTP) Size(path string) (size int, err error) {
 
 	return strconv.Atoi(line)
 }
+

--- a/ftp.go
+++ b/ftp.go
@@ -319,6 +319,39 @@ func (ftp *FTP) receive() (string, error) {
 	return line, err
 }
 
+func (ftp *FTP) receiveNoDiscard() (string, error) {
+	line, err := ftp.receiveLine()
+
+	if err != nil {
+		return line, err
+	}
+
+	if (len(line) >= 4) && (line[3] == '-') {
+		//Multiline response
+		closingCode := line[:3] + " "
+		for {
+			str, err := ftp.receiveLine()
+			line = line + str
+			if err != nil {
+				return line, err
+			}
+			if len(str) < 4 {
+				if ftp.debug {
+					log.Println("Uncorrectly terminated response")
+				}
+				break
+			} else {
+				if str[:4] == closingCode {
+					break
+				}
+			}
+		}
+	}
+	//ftp.ReadAndDiscard()
+	//fmt.Println(line)
+	return line, err
+}
+
 func (ftp *FTP) send(command string, arguments ...interface{}) error {
 	if ftp.debug {
 		log.Printf("> %s", fmt.Sprintf(command, arguments...))
@@ -562,7 +595,7 @@ func (ftp *FTP) List(path string) (files []string, err error) {
 	defer pconn.Close()
 
 	var line string
-	if line, err = ftp.receive(); err != nil {
+	if line, err = ftp.receiveNoDiscard(); err != nil {
 		return
 	}
 
@@ -572,7 +605,7 @@ func (ftp *FTP) List(path string) (files []string, err error) {
 			return
 		}
 
-		if line, err = ftp.receive(); err != nil {
+		if line, err = ftp.receiveNoDiscard(); err != nil {
 			return
 		}
 


### PR DESCRIPTION
There is a problem on List function . It sometimes hangs up if server sends responses too fast. 
List awaits 2 responses:
150 Opening data channel for directory listing ...
and then
226 Successfully transferred
without sending anything. and first receive call can erase the second answer. What is actually happened on my server configuration. 
