### PR TITLE
Fix File Upload

### DIFF
--- a/ftp.go
+++ b/ftp.go
@@ -412,6 +412,7 @@ func (ftp *FTP) Stor(path string, r io.Reader) (err error) {
 	if _, err = io.Copy(pconn, r); err != nil {
 		return
 	}
+	pconn.Close()
 
 	if line, err = ftp.receive(); err != nil {
 		return

--- a/upload.go
+++ b/upload.go
@@ -69,6 +69,7 @@ func (ftp *FTP) copyFile(localPath, serverPath string) (err error) {
 	if file, err = os.Open(localPath); err != nil {
 		return err
 	}
+	defer file.Close()
 	if err := ftp.Stor(serverPath, file); err != nil {
 		return err
 	}


### PR DESCRIPTION
Upload hangs due to unclosed connection. "226 Successfully transferred ..." message cannot be read due to unclosed connection. This patch fixes the problem.
